### PR TITLE
Force Close no Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /mdi-maui/obj
 /mdi-maui/bin/Debug/net8.0-windows10.0.19041.0/win10-x64/AppX
 /mdi-maui/bin/Debug/net8.0-windows10.0.19041.0/win10-x64
+/mdi-maui/bin/Debug/net8.0-android
+/mdi-maui/bin/Release/net8.0-android
+/mdi-maui/bin/Release/net8.0-windows10.0.19041.0/win10-x64

--- a/mdi-maui/Controls/MDIContainer.cs
+++ b/mdi-maui/Controls/MDIContainer.cs
@@ -8,26 +8,15 @@ namespace mdi_maui.Controls;
 public partial class MDIContainer : ContentView
 {
     #region Properties
-    public static readonly BindableProperty WindowsProperty = BindableProperty.Create(
-        nameof(Windows),
-        typeof(ObservableCollection<MDIWindow>),
-        typeof(MDIContainer),
-        propertyChanged: OnWindowsChanged);
-
-    public ObservableCollection<MDIWindow> Windows
+    public static readonly BindableProperty MDIWindowsProperty = BindableProperty.Create(nameof(MDIWindows), typeof(ObservableCollection<MDIWindow>), typeof(MDIContainer), propertyChanged: OnMDIWindowsChanged);
+    public ObservableCollection<MDIWindow> MDIWindows
     {
-        get => (ObservableCollection<MDIWindow>)GetValue(WindowsProperty);
-        set => SetValue(WindowsProperty, value);
+        get => (ObservableCollection<MDIWindow>)GetValue(MDIWindowsProperty);
+        set => SetValue(MDIWindowsProperty, value);
     }
 
-    public static readonly BindableProperty ActiveWindowProperty = BindableProperty.Create(
-        nameof(ActiveWindow),
-        typeof(MDIWindow),
-        typeof(MDIContainer),
-        null,
-        propertyChanged: OnActiveWindowChanged,
-        defaultBindingMode: BindingMode.TwoWay);
 
+    public static readonly BindableProperty ActiveWindowProperty = BindableProperty.Create(nameof(ActiveWindow), typeof(MDIWindow), typeof(MDIContainer), null, propertyChanged: OnActiveWindowChanged, defaultBindingMode: BindingMode.TwoWay);
     public MDIWindow? ActiveWindow
     {
         get => (MDIWindow?)GetValue(ActiveWindowProperty);
@@ -56,16 +45,16 @@ public partial class MDIContainer : ContentView
     #endregion
 
     #region Private Methods
-    private static void OnWindowsChanged(BindableObject bindable, object oldValue, object newValue)
+    private static void OnMDIWindowsChanged(BindableObject bindable, object oldValue, object newValue)
     {
         if (bindable is MDIContainer container)
         {
             if (oldValue is ObservableCollection<MDIWindow> oldCollection)
-                oldCollection.CollectionChanged -= container.OnWindowsCollectionChanged;
+                oldCollection.CollectionChanged -= container.OnMDIWindowsCollectionChanged;
 
             if (newValue is ObservableCollection<MDIWindow> newCollection)
             {
-                newCollection.CollectionChanged += container.OnWindowsCollectionChanged;
+                newCollection.CollectionChanged += container.OnMDIWindowsCollectionChanged;
                 container.UpdateWindows();
             }
             else
@@ -81,7 +70,7 @@ public partial class MDIContainer : ContentView
             container.SetActiveWindow(newValue as MDIWindow);
     }
 
-    private void OnWindowsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    private void OnMDIWindowsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         if (e.Action == NotifyCollectionChangedAction.Add && e.NewItems != null)
         {
@@ -99,9 +88,9 @@ public partial class MDIContainer : ContentView
     private void UpdateWindows()
     {
         _layout.Children.Clear();
-        if (Windows != null)
+        if (MDIWindows != null)
         {
-            foreach (var window in Windows)
+            foreach (var window in MDIWindows)
                 AddWindow(window);
         }
     }
@@ -156,9 +145,9 @@ public partial class MDIContainer : ContentView
 
     private void OnWindowClosing(object? sender, EventArgs e)
     {
-        if (sender is MDIWindow window && Windows.Contains(window))
+        if (sender is MDIWindow window && MDIWindows.Contains(window))
         {
-            Windows.Remove(window);
+            MDIWindows.Remove(window);
         }
     }
 
@@ -175,7 +164,7 @@ public partial class MDIContainer : ContentView
 
     private void OnSizeChanged(object? sender, EventArgs e)
     {
-        foreach (var window in Windows ?? Enumerable.Empty<MDIWindow>())
+        foreach (var window in MDIWindows ?? Enumerable.Empty<MDIWindow>())
         {
             window.AdjustPosition();
         }

--- a/mdi-maui/Controls/MDIWindow.cs
+++ b/mdi-maui/Controls/MDIWindow.cs
@@ -228,16 +228,18 @@ public partial class MDIWindow : ContentView, IDisposable, INotifyPropertyChange
 
     public void AdjustPosition()
     {
-        if (ParentContainer == null) return;
+        if (ParentContainer == null || ParentContainer.MDIWindows == null) return;
 
-        double containerWidth = ParentContainer.Width;
-        double containerHeight = ParentContainer.Height;
+        foreach (var window in ParentContainer.MDIWindows)
+        {
+            window.WindowWidth = Math.Min(window.WindowWidth, ParentContainer.Width);
+            window.WindowHeight = Math.Min(window.WindowHeight, ParentContainer.Height);
 
-        X = Math.Clamp(X, 0, containerWidth - WindowWidth);
-        Y = Math.Clamp(Y, 0, containerHeight - WindowHeight);
+            window.X = Math.Clamp(window.X, 0, Math.Max(0, ParentContainer.Width - window.WindowWidth));
+            window.Y = Math.Clamp(window.Y, 0, Math.Max(0, ParentContainer.Height - window.WindowHeight));
 
-        WindowWidth = Math.Min(WindowWidth, containerWidth);
-        WindowHeight = Math.Min(WindowHeight, containerHeight);
+            AbsoluteLayout.SetLayoutBounds(window, new Rect(window.X, window.Y, window.WindowWidth, window.WindowHeight));
+        }
     }
 
     public double GetDistanceTo(MDIWindow otherWindow)

--- a/mdi-maui/MainPage.xaml
+++ b/mdi-maui/MainPage.xaml
@@ -34,7 +34,7 @@
                 <Grid>
                     <Image Source="background.jpg" Aspect="Fill" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" />
                     <controls:MDIContainer x:Name="MDIContainer" 
-                                       Windows="{Binding Windows}"
+                                       MDIWindows="{Binding Windows}"
                                        ActiveWindow="{Binding ActiveWindow, Mode=TwoWay}" 
                                        HorizontalOptions="Fill" 
                                        VerticalOptions="Fill"


### PR DESCRIPTION
Corrige #1 
Foi implementada uma correção no método AdjustPosition do MDIWindow para garantir que as janelas fiquem sempre dentro dos limites visíveis do MDIContainer, mesmo em dispositivos com diferentes tamanhos de tela ou orientações. Agora, o tamanho das janelas é ajustado dinamicamente para não exceder as dimensões do contêiner, e suas posições são limitadas para evitar que saiam da área visível. Além disso, foi adicionada uma lógica para gerenciar a coleção de janelas (MDIWindows) no MDIContainer, garantindo que alterações na interface sejam refletidas corretamente, prevenindo falhas durante o uso.

## Resumo por Sourcery

Corrigir a lógica de posicionamento de janelas no MDIContainer para garantir que as janelas permaneçam dentro dos limites visíveis em diferentes tamanhos e orientações de tela, e renomear a propriedade Windows para MDIWindows para maior clareza.

Correções de Bugs:
- Corrigir o posicionamento de janelas no MDIContainer para garantir que as janelas permaneçam dentro dos limites visíveis em vários tamanhos e orientações de tela.

Melhorias:
- Renomear a propriedade Windows para MDIWindows no MDIContainer para maior clareza e consistência.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix window positioning logic in MDIContainer to ensure windows stay within visible bounds across different screen sizes and orientations, and rename Windows property to MDIWindows for clarity.

Bug Fixes:
- Fix window positioning in MDIContainer to ensure windows remain within visible bounds on various screen sizes and orientations.

Enhancements:
- Rename Windows property to MDIWindows in MDIContainer for clarity and consistency.

</details>